### PR TITLE
Add support for speech server atributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 .settings
 .classpath
 .orig
+*.iml
 */dependency-reduced-pom.xml
 .*

--- a/pom.xml
+++ b/pom.xml
@@ -22,18 +22,19 @@
     <javasdk.version>1.8</javasdk.version>
     <websocket.version>1.1</websocket.version>
     <junit.version>4.12</junit.version>
+    <jackson.version>2.13.2</jackson.version>
     <log4j.version>1.2.17</log4j.version>
-    <sfl4j.version>1.7.30</sfl4j.version>
-    <tyrus.version>1.17</tyrus.version>
+    <sfl4j.version>1.7.36</sfl4j.version>
+    <tyrus.version>1.18</tyrus.version>
 
-	<skipTests>true</skipTests>
+    <skipTests>true</skipTests>
 
-    <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
-	<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-	<maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-	<maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
-	<maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
-	<maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+    <maven-release-plugin.version>3.0.0-M5</maven-release-plugin.version>
+    <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+    <maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>
+    <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M6</maven-surefire-plugin.version>
+    <maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -41,12 +42,12 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.10.0.pr1</version>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-xml</artifactId>
-        <version>2.9.3</version>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.websocket</groupId>

--- a/recognizer-protocol/src/main/java/br/com/cpqd/asr/protocol/AsrMessage.java
+++ b/recognizer-protocol/src/main/java/br/com/cpqd/asr/protocol/AsrMessage.java
@@ -49,7 +49,7 @@ public abstract class AsrMessage {
 		START_INPUT_TIMERS, SET_PARAMETERS, GET_PARAMETERS, DEFINE_GRAMMAR, START_OF_SPEECH,
 		END_OF_SPEECH, RECOGNITION_RESULT, INTERPRET_TEXT, RESPONSE
 
-	};
+	}
 
 	/** Defines the message type. */
 	private AsrMessageType mType;
@@ -65,6 +65,9 @@ public abstract class AsrMessage {
 
 	/** The message body content-type. */
 	private String contentType;
+
+	/** The message protocol version. */
+	private String protocolVersion;
 
 	public AsrMessageType getmType() {
 		return mType;
@@ -104,6 +107,14 @@ public abstract class AsrMessage {
 
 	public void setContentType(String contentType) {
 		this.contentType = contentType;
+	}
+
+	public String getProtocolVersion() {
+		return protocolVersion;
+	}
+
+	public void setProtocolVersion(String protocolVersion) {
+		this.protocolVersion = protocolVersion;
 	}
 
 	@Override
@@ -152,7 +163,7 @@ public abstract class AsrMessage {
 	 * @throws DecodeException
 	 *             em caso de erro de decodificação.
 	 */
-	public static AsrMessage createMessage(AsrMessageType type, HashMap<String, String> headers, byte[] content)
+	public static AsrMessage createMessage(AsrMessageType type, String version, HashMap<String, String> headers, byte[] content)
 			throws DecodeException {
 		AsrMessage message = null;
 
@@ -203,8 +214,10 @@ public abstract class AsrMessage {
 			break;
 		}
 
-		if (message != null)
+		if (message != null) {
 			message.populate(headers, content);
+			message.setProtocolVersion(version);
+		}
 		return message;
 	}
 

--- a/recognizer-protocol/src/main/java/br/com/cpqd/asr/protocol/CreateSession.java
+++ b/recognizer-protocol/src/main/java/br/com/cpqd/asr/protocol/CreateSession.java
@@ -29,6 +29,9 @@ public class CreateSession extends AsrMessage {
 
 	private String loggingTag;
 
+	/** Identifier for sharing resources through different sessions. (speech server optional)*/
+	private String channelIdentifier;
+
 	public CreateSession() {
 		setmType(AsrMessageType.CREATE_SESSION);
 	}
@@ -41,6 +44,22 @@ public class CreateSession extends AsrMessage {
 		this.userAgent = userAgent;
 	}
 
+	public String getLoggingTag() {
+		return loggingTag;
+	}
+
+	public void setLoggingTag(String loggingTag) {
+		this.loggingTag = loggingTag;
+	}
+
+	public String getChannelIdentifier() {
+		return channelIdentifier;
+	}
+
+	public void setChannelIdentifier(String channelIdentifier) {
+		this.channelIdentifier = channelIdentifier;
+	}
+
 	@Override
 	public String toString() {
 		return "CreateSession [userAgent=" + userAgent + "]";
@@ -51,8 +70,10 @@ public class CreateSession extends AsrMessage {
 
 		for (String header : headers.keySet()) {
 			try {
-				if ("User-Agent".toLowerCase().equals(header)) {
+				if ("User-Agent".equalsIgnoreCase(header)) {
 					this.userAgent = headers.get(header);
+				} else if ("Channel-Identifier".equalsIgnoreCase(header)) {
+					this.channelIdentifier = headers.get(header);
 				} else if (Header.loggingTag.getHeader().equalsIgnoreCase(header)) {
 					this.loggingTag = headers.get(header);
 				} else {
@@ -66,14 +87,16 @@ public class CreateSession extends AsrMessage {
 
 	@Override
 	public HashMap<String, String> getHeaders() {
-		HashMap<String, String> map = new HashMap<String, String>();
+		HashMap<String, String> map = new HashMap<>();
 		if (this.userAgent != null) {
 			map.put("User-Agent", this.userAgent);
 		}
 		if (this.loggingTag != null) {
 			map.put(Header.loggingTag.getHeader(), this.loggingTag);
 		}
-
+		if (this.channelIdentifier != null) {
+			map.put("Channel-Identifier", this.channelIdentifier);
+		}
 		return map;
 	}
 

--- a/recognizer-protocol/src/main/java/br/com/cpqd/asr/protocol/RecognitionParameters.java
+++ b/recognizer-protocol/src/main/java/br/com/cpqd/asr/protocol/RecognitionParameters.java
@@ -63,7 +63,12 @@ public class RecognitionParameters {
 		textifyEnabled("textify.enabled"),
 		textifyFormattingEnabled("textify.formatting.enabled"),
 		textifyFormattingRules("textify.formatting.rules"),
-		loggingTag("loggingTag");
+		loggingTag("loggingTag"),
+
+		// versao 2.4 - speech server
+		inferAgeEnabled("Infer-age-enabled"),
+		inferEmotionEnabled("Infer-emotion-enabled"),
+		inferGenderEnabled("Infer-gender-enabled");
 
 		/** valor do header na comunicação websocket. */
 		private String headerName;
@@ -120,6 +125,10 @@ public class RecognitionParameters {
 	private String textifyFormattingRules;
 	private String loggingTag;
 
+	private Boolean inferAgeEnabled;
+	private Boolean inferEmotionEnabled;
+	private Boolean inferGenderEnabled;
+
 	/**
 	 * Obtém uma lista de todos os parametros de configuração.
 	 * 
@@ -156,7 +165,7 @@ public class RecognitionParameters {
 				String param = m.getName().substring(3, 4).toLowerCase() + m.getName().substring(4);
 				// obtem o parametro equivalente, a partir do atributo da classe
 				// RecognitionParameters
-				Header h = Header.valueOf(param);
+				Header h = Header.fromHeader(param);
 				if (h == null) {
 					logger.warn("Parameter not mapped in Header enum: {}", param);
 					continue;
@@ -394,6 +403,30 @@ public class RecognitionParameters {
 
 	public void setLoggingTag(String loggingTag) {
 		this.loggingTag = loggingTag;
+	}
+
+	public Boolean getInferAgeEnabled() {
+		return inferAgeEnabled;
+	}
+
+	public void setInferAgeEnabled(Boolean inferAgeEnabled) {
+		this.inferAgeEnabled = inferAgeEnabled;
+	}
+
+	public Boolean getInferEmotionEnabled() {
+		return inferEmotionEnabled;
+	}
+
+	public void setInferEmotionEnabled(Boolean inferEmotionEnabled) {
+		this.inferEmotionEnabled = inferEmotionEnabled;
+	}
+
+	public Boolean getInferGenderEnabled() {
+		return inferGenderEnabled;
+	}
+
+	public void setInferGenderEnabled(Boolean inferGenderEnabled) {
+		this.inferGenderEnabled = inferGenderEnabled;
 	}
 
 	@Override

--- a/recognizer-protocol/src/main/java/br/com/cpqd/asr/protocol/RecognitionParameters.java
+++ b/recognizer-protocol/src/main/java/br/com/cpqd/asr/protocol/RecognitionParameters.java
@@ -64,7 +64,7 @@ public class RecognitionParameters {
 		textifyFormattingEnabled("textify.formatting.enabled"),
 		textifyFormattingRules("textify.formatting.rules"),
 		loggingTag("loggingTag"),
-
+		accountTag("license.manager.accountTag"),
 		// versao 2.4 - speech server
 		inferAgeEnabled("Infer-age-enabled"),
 		inferEmotionEnabled("Infer-emotion-enabled"),
@@ -124,6 +124,7 @@ public class RecognitionParameters {
 	private Boolean textifyFormattingEnabled;
 	private String textifyFormattingRules;
 	private String loggingTag;
+	private String accountTag;
 
 	private Boolean inferAgeEnabled;
 	private Boolean inferEmotionEnabled;
@@ -404,6 +405,14 @@ public class RecognitionParameters {
 	public void setLoggingTag(String loggingTag) {
 		this.loggingTag = loggingTag;
 	}
+
+    public String getAccountTag() {
+        return accountTag;
+    }
+
+    public void setAccountTag(String accountTag) {
+        this.accountTag = accountTag;
+    }
 
 	public Boolean getInferAgeEnabled() {
 		return inferAgeEnabled;

--- a/recognizer-protocol/src/main/java/br/com/cpqd/asr/protocol/RecognitionResult.java
+++ b/recognizer-protocol/src/main/java/br/com/cpqd/asr/protocol/RecognitionResult.java
@@ -16,8 +16,11 @@
 package br.com.cpqd.asr.protocol;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -51,6 +54,14 @@ public class RecognitionResult {
 	@JacksonXmlElementWrapper(localName = "alternatives")
 	@JacksonXmlProperty(localName = "alternative")
 	private List<RecognitionAlternative> alternatives = new ArrayList<>();
+
+	// Speech Server
+	@JsonProperty("age_scores") @JsonInclude(NON_NULL)
+	private HashMap<String, Object> ageScores;
+	@JsonProperty("emotion_scores") @JsonInclude(NON_NULL)
+	private HashMap<String, Object> emotionScores;
+	@JsonProperty("gender_scores") @JsonInclude(NON_NULL)
+	private HashMap<String, Object> genderScores;
 
 	public boolean isLastSegment() {
 		return lastSegment;
@@ -110,6 +121,30 @@ public class RecognitionResult {
 
 	public void setRecognitionStatus(RecognitionStatus status) {
 		this.recognitionStatus = status;
+	}
+
+	public HashMap<String, Object> getAgeScores() {
+		return ageScores;
+	}
+
+	public void setAgeScores(HashMap<String, Object> ageScores) {
+		this.ageScores = ageScores;
+	}
+
+	public HashMap<String, Object> getEmotionScores() {
+		return emotionScores;
+	}
+
+	public void setEmotionScores(HashMap<String, Object> emotionScores) {
+		this.emotionScores = emotionScores;
+	}
+
+	public HashMap<String, Object> getGenderScores() {
+		return genderScores;
+	}
+
+	public void setGenderScores(HashMap<String, Object> genderScores) {
+		this.genderScores = genderScores;
 	}
 
 	@Override

--- a/recognizer-protocol/src/main/java/br/com/cpqd/asr/protocol/StartRecognition.java
+++ b/recognizer-protocol/src/main/java/br/com/cpqd/asr/protocol/StartRecognition.java
@@ -42,7 +42,10 @@ public class StartRecognition extends AsrMessage {
 	private String accept;
 
 	/** Additional headers containing the recognition parameters. */
-	private HashMap<String, String> parameters = new LinkedHashMap<String, String>();
+	private HashMap<String, String> parameters = new LinkedHashMap<>();
+
+	private String mediaType;
+	private Boolean verifyBuffer;
 
 	public StartRecognition() {
 		super();
@@ -64,6 +67,22 @@ public class StartRecognition extends AsrMessage {
 
 	public void setAccept(String contentType) {
 		this.accept = contentType;
+	}
+
+	public String getMediaType() {
+		return mediaType;
+	}
+
+	public void setMediaType(String mediaType) {
+		this.mediaType = mediaType;
+	}
+
+	public Boolean getVerifyBuffer() {
+		return verifyBuffer;
+	}
+
+	public void setVerifyBuffer(Boolean verifyBuffer) {
+		this.verifyBuffer = verifyBuffer;
 	}
 
 	/**
@@ -112,6 +131,10 @@ public class StartRecognition extends AsrMessage {
 					this.accept = headers.get(header);
 				} else if ("content-id".equals(header)) {
 					this.lm.setId(headers.get(header));
+				} else if ("Media-Type".equalsIgnoreCase(header)) {
+					this.mediaType = headers.get(header);
+				} else if ("Verify-Buffer-Utterance".equalsIgnoreCase(header)) {
+					this.verifyBuffer = Boolean.getBoolean(headers.get(header));
 				} else {
 					// verifica se o header é um parametro de reconhecimento valido
 					Header h = Header.fromHeader(header);
@@ -142,7 +165,7 @@ public class StartRecognition extends AsrMessage {
 
 			if (getContentType().equals(TEXT_URI_LIST)) {
 				// modelo ligua definido como lista URI
-				ArrayList<String> uriList = new ArrayList<String>();
+				ArrayList<String> uriList = new ArrayList<>();
 				String[] uris = new String(content).split("\\r?\\n");
 				for (int i = 0; i < uris.length; i++) {
 					String str = uris[i].trim();
@@ -174,20 +197,23 @@ public class StartRecognition extends AsrMessage {
 
 	@Override
 	public HashMap<String, String> getHeaders() {
-		HashMap<String, String> map = new HashMap<String, String>();
+		HashMap<String, String> map = new HashMap<>();
 		if (this.lm.getId() != null) {
 			map.put("Content-ID", this.lm.getId());
 		}
-
 		if (this.accept != null) {
 			map.put("Accept", this.accept);
 		}
-
+		if (this.mediaType != null) {
+			map.put("Media-Type", this.mediaType);
+		}
+		if (this.verifyBuffer != null) {
+			map.put("Verify-Buffer-Utterance", this.verifyBuffer.toString());
+		}
 		// adiciona header extras (parametros para o reconhecimento)
 		for (String key : parameters.keySet()) {
 			map.put(key, parameters.get(key));
 		}
-
 		return map;
 	}
 

--- a/recognizer-protocol/src/main/java/br/com/cpqd/asr/protocol/WordDetail.java
+++ b/recognizer-protocol/src/main/java/br/com/cpqd/asr/protocol/WordDetail.java
@@ -21,20 +21,29 @@ package br.com.cpqd.asr.protocol;
  */
 public enum WordDetail {
 
-	ALL, FIRST, NONE;
+	ALL(2), FIRST(1), NONE(0);
 
-	public static WordDetail fromString(String str) {
+	private final int value;
+
+	WordDetail(int value) {
+		this.value = value;
+	}
+
+	public int getValue() {
+		return this.value;
+	}
+
+	public static WordDetail from(String str) {
 		if (str == null) {
 			return null;
-		} else if (str.toLowerCase().equals("all")) {
+		} else if ("2".equalsIgnoreCase(str)) {
 			return ALL;
-		} else if (str.toLowerCase().equals("first")) {
+		} else if ("1".equalsIgnoreCase(str)) {
 			return FIRST;
-		} else if (str.toLowerCase().equals("none")) {
+		} else if ("0".equalsIgnoreCase(str)) {
 			return NONE;
 		} else {
 			return null;
 		}
 	}
-	
 }

--- a/recognizer/src/main/java/br/com/cpqd/asr/recognizer/FileAudioSource.java
+++ b/recognizer/src/main/java/br/com/cpqd/asr/recognizer/FileAudioSource.java
@@ -41,7 +41,7 @@ public class FileAudioSource implements AudioSource {
 	 * Creates a new instance.
 	 *
 	 * @param file
-	 *            the file.
+	 *            the file (in WAV format).
 	 * @throws IOException
 	 *             if an I/O error occurs.
 	 */
@@ -53,8 +53,19 @@ public class FileAudioSource implements AudioSource {
 	 * Creates a new instance.
 	 *
 	 * @param file File to be read
+	 * @param contentType The audio format.
+	 *
+	 * @throws IOException
+	 */
+	public FileAudioSource(File file, String contentType) throws IOException {
+		this(file, false, contentType);
+	}
+	/**
+	 * Creates a new instance.
+	 *
+	 * @param file File to be read
 	 * @param decodeAudio 'true' if audio must be converted to RAW before sending.
-	 * @param contentType The output audio format (after decoding).
+	 * @param contentType The output audio format (if decodeAudio = 'false', not converted).
 	 *
 	 * @throws IOException
 	 */

--- a/recognizer/src/main/java/br/com/cpqd/asr/recognizer/SpeechRecognizer.java
+++ b/recognizer/src/main/java/br/com/cpqd/asr/recognizer/SpeechRecognizer.java
@@ -162,6 +162,12 @@ public interface SpeechRecognizer {
 		/** The maximum time the ASR session is kept open and idle. */
 		protected int maxSessionIdleSeconds;
 
+		/** The API protocol version. */
+		protected String protocolVersion;
+
+		/** The channel identifier for the ASR Resource. */
+		protected String channelIdentifier;
+
 		/**
 		 * Private constructor. Defines default configuration parameters.
 		 *
@@ -308,6 +314,15 @@ public interface SpeechRecognizer {
 			return this;
 		}
 
-	}
+        public SpeechRecognizer.Builder version(String protocolVersion) {
+			this.protocolVersion = protocolVersion;
+			return this;
+        }
+
+		public SpeechRecognizer.Builder channelIdentifier(String channelIdentifier) {
+			this.channelIdentifier = channelIdentifier;
+			return this;
+		}
+    }
 
 }

--- a/recognizer/src/main/java/br/com/cpqd/asr/recognizer/SpeechRecognizerImpl.java
+++ b/recognizer/src/main/java/br/com/cpqd/asr/recognizer/SpeechRecognizerImpl.java
@@ -107,7 +107,7 @@ public class SpeechRecognizerImpl implements SpeechRecognizer, RecognitionListen
 
 		client = new AsrClientEndpoint(builder.uri, builder.username, builder.password);
 		client.getListeners().add(this);
-		if (builder.listeners.size() > 0)
+		if (!builder.listeners.isEmpty())
 			client.getListeners().addAll(builder.listeners);
 		client.setSessionTimeoutTime(builder.maxSessionIdleSeconds >= 0 ? builder.maxSessionIdleSeconds * 1000 : -1);
 
@@ -214,9 +214,8 @@ public class SpeechRecognizerImpl implements SpeechRecognizer, RecognitionListen
 					}
 
 				} else {
-					logger.error("Error creating session ({}): {}",
-							(response != null ? response.getSessionStatus() : null),
-							(response != null ? response.getErrorMessage() : null));
+                    logger.error("Error creating session ({}): {}", response.getSessionStatus(),
+                            response.getErrorMessage());
 					handle = null;
 					throw new RecognitionException(RecognitionErrorCode.FAILURE, response.getErrorMessage());
 				}

--- a/recognizer/src/main/java/br/com/cpqd/asr/recognizer/SpeechRecognizerImpl.java
+++ b/recognizer/src/main/java/br/com/cpqd/asr/recognizer/SpeechRecognizerImpl.java
@@ -141,6 +141,7 @@ public class SpeechRecognizerImpl implements SpeechRecognizer, RecognitionListen
 
 		CancelRecognition message = new CancelRecognition();
 		message.setHandle(this.handle);
+		message.setProtocolVersion(builder.protocolVersion);
 		try {
 			ResponseMessage response = client.sendMessageAndWait(message);
 
@@ -192,6 +193,9 @@ public class SpeechRecognizerImpl implements SpeechRecognizer, RecognitionListen
 
 			CreateSession message = new CreateSession();
 			message.setUserAgent(this.builder.userAgent);
+			Optional.ofNullable(builder.recogConfig).ifPresent(c -> message.setLoggingTag(c.getLoggingTag()));
+			message.setProtocolVersion(builder.protocolVersion);
+			message.setChannelIdentifier(builder.channelIdentifier);
 
 			try {
 				ResponseMessage response = client.sendMessageAndWait(message);
@@ -242,7 +246,7 @@ public class SpeechRecognizerImpl implements SpeechRecognizer, RecognitionListen
 
 		ReleaseSession message = new ReleaseSession();
 		message.setHandle(this.handle);
-
+		message.setProtocolVersion(builder.protocolVersion);
 		try {
 			ResponseMessage response = client.sendMessageAndWait(message);
 			if (response == null) {
@@ -292,7 +296,7 @@ public class SpeechRecognizerImpl implements SpeechRecognizer, RecognitionListen
 		// cria uma thread para ler o audio source e enviar os pacotes para o servidor
 		readerTask = new ReaderTask(audio);
 
-		startRecognition(lm, recogConfig);
+		startRecognition(lm, recogConfig, audio.getContentType());
 	}
 
 	@Override
@@ -481,6 +485,7 @@ public class SpeechRecognizerImpl implements SpeechRecognizer, RecognitionListen
 
 		SetParametersMessage message = new SetParametersMessage();
 		message.setHandle(this.handle);
+		message.setProtocolVersion(builder.protocolVersion);
 		message.setRecognitionParameters(parameters.getParameterMap());
 
 		try {
@@ -510,6 +515,7 @@ public class SpeechRecognizerImpl implements SpeechRecognizer, RecognitionListen
 
 		DefineGrammarMessage message = new DefineGrammarMessage();
 		message.setHandle(this.handle);
+		message.setProtocolVersion(builder.protocolVersion);
 		message.setLanguageModel(languageModel);
 
 		if (languageModel.getContentType() != null) {
@@ -545,18 +551,23 @@ public class SpeechRecognizerImpl implements SpeechRecognizer, RecognitionListen
 	 *            the language model list.
 	 * @param parameters
 	 *            the recognition parameters.
+	 * @param mediaType
 	 * @return true if the server is listening
 	 * @throws IOException
 	 *             in case an I/O error occurs.
 	 * @throws RecognitionException
 	 *             some error in the recogniton process.
 	 */
-	private boolean startRecognition(LanguageModelList lmList, RecognitionConfig parameters)
+	private boolean startRecognition(LanguageModelList lmList, RecognitionConfig parameters, String mediaType)
 			throws IOException, RecognitionException {
 
 		this.lastResultTime = Instant.now();
 		StartRecognition message = new StartRecognition();
 		message.setHandle(this.handle);
+		message.setProtocolVersion(builder.protocolVersion);
+		if (mediaType != null) {
+			message.setMediaType(mediaType);
+		}
 
 		List<String> uriList = Optional.ofNullable(lmList.getUriList()).orElse(new ArrayList<>());
 		// define multiplas gramaticas

--- a/recognizer/src/main/java/br/com/cpqd/asr/recognizer/model/RecognitionConfig.java
+++ b/recognizer/src/main/java/br/com/cpqd/asr/recognizer/model/RecognitionConfig.java
@@ -137,6 +137,14 @@ public class RecognitionConfig {
 		put("decoder.confidenceThreshold", decoderConfidenceThreshold);
 	}
 
+	public Integer getWordDetails() {
+		return getInteger("decoder.wordDetails");
+	}
+
+	public void setWordDetails(Integer wordDetails) {
+		put("decoder.wordDetails", wordDetails);
+	}
+
 	public String getWordHints() {
 		return getString("hints.words");
 	}
@@ -175,6 +183,30 @@ public class RecognitionConfig {
 
 	private void setLoggingTag(String loggingTag) {
 		put("loggingTag", loggingTag);
+	}
+
+	public Boolean getInferAgeEnabled() {
+		return getBoolean("Infer-age-enabled");
+	}
+
+	public void setInferAgeEnabled(Boolean inferAgeEnabled) {
+		put("Infer-age-enabled", inferAgeEnabled);
+	}
+
+	public Boolean getInferEmotionEnabled() {
+		return getBoolean("Infer-emotion-enabled");
+	}
+
+	public void setInferEmotionEnabled(Boolean inferEmotionEnabled) {
+		put("Infer-emotion-enabled", inferEmotionEnabled);
+	}
+
+	public Boolean getInferGenderEnabled() {
+		return getBoolean("Infer-gender-enabled");
+	}
+
+	public void setInferGenderEnabled(Boolean inferGenderEnabled) {
+		put("Infer-gender-enabled", inferGenderEnabled);
 	}
 
 	private void put(String key, Object value) {
@@ -247,11 +279,17 @@ public class RecognitionConfig {
 		private Integer endPointerAutoLevelLen;
 		private Integer endPointerLevelMode;
 		private Integer endPointerLevelThreshold;
+		private Integer wordDetails;
 		private String wordHints;
 		private Boolean textifyEnabled;
 		private Boolean textifyFormattingEnabled;
 		private String textifyFormattingRules;
 		private String loggingTag;
+
+		// speech server
+		private Boolean inferAgeEnabled;
+		private Boolean inferEmotionEnabled;
+		private Boolean inferGenderEnabled;
 
 		/**
 		 * Creates a new instance of the RecognitionConfig object.
@@ -274,11 +312,16 @@ public class RecognitionConfig {
 			config.setEndpointerLevelThreshold(endPointerLevelThreshold);
 			config.setNoInputTimeoutEnabled(noInputTimeoutEnabled);
 			config.setRecognitionTimeoutEnabled(recognitionTimeoutEnabled);
+			config.setWordDetails(wordDetails);
 			config.setWordHints(wordHints);
 			config.setTextifyEnabled(textifyEnabled);
 			config.setTextifyFormattingEnabled(textifyFormattingEnabled);
 			config.setTextifyFormattingRules(textifyFormattingRules);
 			config.setLoggingTag(loggingTag);
+
+			config.setInferAgeEnabled(inferAgeEnabled);
+			config.setInferEmotionEnabled(inferEmotionEnabled);
+			config.setInferGenderEnabled(inferGenderEnabled);
 
 			return config;
 		}
@@ -367,6 +410,10 @@ public class RecognitionConfig {
 			this.textifyFormattingRules = textifyFormattingRules;
 			return this;
 		}
+		public RecognitionConfig.Builder wordDetails(int wordDetails) {
+			this.wordDetails = wordDetails;
+			return this;
+		}
 
 		public RecognitionConfig.Builder wordHints(String wordHints) {
 			this.wordHints = wordHints;
@@ -375,6 +422,21 @@ public class RecognitionConfig {
 
 		public RecognitionConfig.Builder loggingTag(String value) {
 			this.loggingTag = value;
+			return this;
+		}
+
+		public RecognitionConfig.Builder inferAgeEnabled(Boolean value) {
+			this.inferAgeEnabled = value;
+			return this;
+		}
+
+		public RecognitionConfig.Builder inferEmotionEnabled(Boolean value) {
+			this.inferEmotionEnabled = value;
+			return this;
+		}
+
+		public RecognitionConfig.Builder inferGenderEnabled(Boolean value) {
+			this.inferGenderEnabled = value;
 			return this;
 		}
 	}

--- a/recognizer/src/main/java/br/com/cpqd/asr/recognizer/model/RecognitionConfig.java
+++ b/recognizer/src/main/java/br/com/cpqd/asr/recognizer/model/RecognitionConfig.java
@@ -23,422 +23,453 @@ import java.util.Iterator;
  */
 public class RecognitionConfig {
 
-	private HashMap<String, String> map = new HashMap<>();
-
-	public Boolean getNoInputTimeoutEnabled() {
-		return getBoolean("noInputTimeout.enabled");
-	}
-
-	private void setNoInputTimeoutEnabled(Boolean noInputTimeoutEnabled) {
-		put("noInputTimeout.enabled", noInputTimeoutEnabled);
-	}
-
-	public Integer getNoInputTimeout() {
-		return getInteger("noInputTimeout.value");
-	}
-
-	private void setNoInputTimeout(Integer noInputTimeout) {
-		put("noInputTimeout.value", noInputTimeout);
-	}
-
-	public Boolean getRecognitionTimeoutEnabled() {
-		return getBoolean("recognitionTimeout.enabled");
-	}
-
-	private void setRecognitionTimeoutEnabled(Boolean recognitionTimeoutEnabled) {
-		put("recognitionTimeout.enabled", recognitionTimeoutEnabled);
-	}
-
-	public Integer getRecognitionTimeout() {
-		return getInteger("recognitionTimeout.value");
-	}
-
-	private void setRecognitionTimeout(Integer recognitionTimeout) {
-		put("recognitionTimeout.value", recognitionTimeout);
-	}
-
-	public Boolean getStartInputTimers() {
-		return getBoolean("decoder.startInputTimers");
-	}
-
-	private void setStartInputTimers(Boolean decoderStartInputTimers) {
-		put("decoder.startInputTimers", decoderStartInputTimers);
-	}
-
-	public Integer getMaxSentences() {
-		return getInteger("decoder.maxSentences");
-	}
-
-	private void setMaxSentences(Integer decoderMaxSentences) {
-		put("decoder.maxSentences", decoderMaxSentences);
-	}
-
-	public Integer getHeadMarginMiliseconds() {
-		return getInteger("endpointer.headMargin");
-	}
-
-	private void setHeadMarginMiliseconds(Integer endpointerHeadMargin) {
-		put("endpointer.headMargin", endpointerHeadMargin);
-	}
-
-	public Integer getTailMarginMiliseconds() {
-		return getInteger("endpointer.tailMargin");
-	}
-
-	private void setTailMarginMiliseconds(Integer endpointerTailMargin) {
-		put("endpointer.tailMargin", endpointerTailMargin);
-	}
-
-	public Integer getWaitEndMiliseconds() {
-		return getInteger("endpointer.waitEnd");
-	}
-
-	private void setWaitEndMiliseconds(Integer endpointerWaitEnd) {
-		put("endpointer.waitEnd", endpointerWaitEnd);
-	}
-
-	public Integer getEndpointerLevelThreshold() {
-		return getInteger("endpointer.levelThreshold");
-	}
-
-	private void setEndpointerLevelThreshold(Integer endpointerLevelThreshold) {
-		put("endpointer.levelThreshold", endpointerLevelThreshold);
-	}
-
-	public Integer getEndpointerLevelMode() {
-		return getInteger("endpointer.levelMode");
-	}
-
-	private void setEndpointerLevelMode(Integer endpointerLevelMode) {
-		put("endpointer.levelMode", endpointerLevelMode);
-	}
-
-	public Integer getEndpointerAutoLevelLen() {
-		return getInteger("endpointer.autoLevelLen");
-	}
-
-	private void setEndpointerAutoLevelLen(Integer endpointerAutoLevelLen) {
-		put("endpointer.autoLevelLen", endpointerAutoLevelLen);
-	}
-
-	public Boolean getContinuousMode() {
-		return getBoolean("decoder.continuousMode");
-	}
-
-	private void setContinuousMode(Boolean continuousMode) {
-		put("decoder.continuousMode", continuousMode);
-	}
-
-	public Integer getConfidenceThreshold() {
-		return getInteger("decoder.confidenceThreshold");
-	}
-
-	private void setConfidenceThreshold(Integer decoderConfidenceThreshold) {
-		put("decoder.confidenceThreshold", decoderConfidenceThreshold);
-	}
-
-	public Integer getWordDetails() {
-		return getInteger("decoder.wordDetails");
-	}
-
-	public void setWordDetails(Integer wordDetails) {
-		put("decoder.wordDetails", wordDetails);
-	}
-
-	public String getWordHints() {
-		return getString("hints.words");
-	}
-
-	public void setWordHints(String wordHints) {
-		put("hints.words", wordHints);
-	}
-
-	public String getTextifyFormattingRules() {
-		return getString("textify.formatting.rules");
-	}
-
-	public void setTextifyFormattingRules(String textifyFormattingRules) {
-		put("textify.formatting.rules", textifyFormattingRules);
-	}
-
-	public Boolean getTextifyFormattingEnabled() {
-		return getBoolean("textify.formatting.enabled");
-	}
-
-	public void setTextifyFormattingEnabled(Boolean textifyFormattingEnabled) {
-		put("textify.formatting.enabled", textifyFormattingEnabled);
-	}
-
-	public Boolean getTextifyEnabled() {
-		return getBoolean("textify.enabled");
-	}
-
-	public void setTextifyEnabled(Boolean textifyEnabled) {
-		put("textify.enabled", textifyEnabled);
-	}
-
-	public String getLoggingTag() {
-		return getString("loggingTag");
-	}
-
-	private void setLoggingTag(String loggingTag) {
-		put("loggingTag", loggingTag);
-	}
-
-	public Boolean getInferAgeEnabled() {
-		return getBoolean("Infer-age-enabled");
-	}
-
-	public void setInferAgeEnabled(Boolean inferAgeEnabled) {
-		put("Infer-age-enabled", inferAgeEnabled);
-	}
-
-	public Boolean getInferEmotionEnabled() {
-		return getBoolean("Infer-emotion-enabled");
-	}
-
-	public void setInferEmotionEnabled(Boolean inferEmotionEnabled) {
-		put("Infer-emotion-enabled", inferEmotionEnabled);
-	}
-
-	public Boolean getInferGenderEnabled() {
-		return getBoolean("Infer-gender-enabled");
-	}
-
-	public void setInferGenderEnabled(Boolean inferGenderEnabled) {
-		put("Infer-gender-enabled", inferGenderEnabled);
-	}
-
-	private void put(String key, Object value) {
-		if (value != null)
-			this.map.put(key, value.toString());
-	}
-
-	private Boolean getBoolean(String key) {
-		String value = this.map.get(key);
-		return (value == null ? null : Boolean.parseBoolean(value));
-	}
-
-	private Integer getInteger(String key) {
-		String value = this.map.get(key);
-		return (value == null ? null : Integer.parseInt(value));
-	}
-
-	private String getString(String key) {
-		return this.map.get(key);
-	}
-
-	public HashMap<String, String> getParameterMap() {
-		return this.map;
-	}
-
-	@Override
-	public String toString() {
-		StringBuffer str = new StringBuffer("RecognitionConfig [");
-		for (Iterator<String> it = map.keySet().iterator(); it.hasNext();) {
-			String key = it.next();
-			if (map.get(key) != null && map.get(key).trim().length() > 0) {
-				str.append(key + "=" + map.get(key));
-			}
-
-			if (it.hasNext()) {
-				str.append(", ");
-			}
-		}
-
-		str.append("]");
-		return str.toString();
-	}
-
-	/**
-	 * Creates a new instance of the object builder.
-	 * 
-	 * @return the Builder object.
-	 */
-	public static RecognitionConfig.Builder builder() {
-		return new RecognitionConfig.Builder();
-	}
-
-	/**
-	 * The Builder object.
-	 *
-	 */
-	public static class Builder {
-
-		private Boolean continuousMode;
-		private Integer confidenceThreshold;
-		private Integer maxSentences;
-		private Integer noInputTimeoutMilis;
-		private Integer recognitionTimeoutSeconds;
-		private Integer headMarginMilis;
-		private Integer tailMarginMilis;
-		private Integer waitEndMilis;
-		private Boolean recognitionTimeoutEnabled;
-		private Boolean noInputTimeoutEnabled;
-		private Boolean startInputTimers;
-		private Integer endPointerAutoLevelLen;
-		private Integer endPointerLevelMode;
-		private Integer endPointerLevelThreshold;
-		private Integer wordDetails;
-		private String wordHints;
-		private Boolean textifyEnabled;
-		private Boolean textifyFormattingEnabled;
-		private String textifyFormattingRules;
-		private String loggingTag;
-
-		// speech server
-		private Boolean inferAgeEnabled;
-		private Boolean inferEmotionEnabled;
-		private Boolean inferGenderEnabled;
-
-		/**
-		 * Creates a new instance of the RecognitionConfig object.
-		 * 
-		 * @return a RecognitionConfig instance.
-		 */
-		public RecognitionConfig build() {
-			RecognitionConfig config = new RecognitionConfig();
-			config.setContinuousMode(continuousMode);
-			config.setConfidenceThreshold(confidenceThreshold);
-			config.setMaxSentences(maxSentences);
-			config.setNoInputTimeout(noInputTimeoutMilis);
-			config.setRecognitionTimeout(recognitionTimeoutSeconds);
-			config.setHeadMarginMiliseconds(headMarginMilis);
-			config.setTailMarginMiliseconds(tailMarginMilis);
-			config.setWaitEndMiliseconds(waitEndMilis);
-			config.setStartInputTimers(startInputTimers);
-			config.setEndpointerAutoLevelLen(endPointerAutoLevelLen);
-			config.setEndpointerLevelMode(endPointerLevelMode);
-			config.setEndpointerLevelThreshold(endPointerLevelThreshold);
-			config.setNoInputTimeoutEnabled(noInputTimeoutEnabled);
-			config.setRecognitionTimeoutEnabled(recognitionTimeoutEnabled);
-			config.setWordDetails(wordDetails);
-			config.setWordHints(wordHints);
-			config.setTextifyEnabled(textifyEnabled);
-			config.setTextifyFormattingEnabled(textifyFormattingEnabled);
-			config.setTextifyFormattingRules(textifyFormattingRules);
-			config.setLoggingTag(loggingTag);
-
-			config.setInferAgeEnabled(inferAgeEnabled);
-			config.setInferEmotionEnabled(inferEmotionEnabled);
-			config.setInferGenderEnabled(inferGenderEnabled);
-
-			return config;
-		}
-
-		public RecognitionConfig.Builder continuousMode(Boolean value) {
-			this.continuousMode = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder confidenceThreshold(Integer value) {
-			this.confidenceThreshold = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder maxSentences(Integer value) {
-			this.maxSentences = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder noInputTimeoutMilis(Integer value) {
-			this.noInputTimeoutMilis = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder recognitionTimeoutSeconds(Integer value) {
-			this.recognitionTimeoutSeconds = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder headMarginMilis(Integer value) {
-			this.headMarginMilis = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder tailMarginMilis(Integer value) {
-			this.tailMarginMilis = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder waitEndMilis(Integer value) {
-			this.waitEndMilis = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder startInputTimers(Boolean value) {
-			this.startInputTimers = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder endPointerAutoLevelLen(Integer value) {
-			this.endPointerAutoLevelLen = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder endPointerLevelMode(Integer value) {
-			this.endPointerLevelMode = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder endPointerLevelThreshold(Integer value) {
-			this.endPointerLevelThreshold = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder noInputTimeoutEnabled(Boolean value) {
-			this.noInputTimeoutEnabled = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder recognitionTimeoutEnabled(Boolean value) {
-			this.recognitionTimeoutEnabled = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder textifyEnabled(Boolean textifyEnabled) {
-			this.textifyEnabled = textifyEnabled;
-			return this;
-		}
-
-		public RecognitionConfig.Builder textifyFormattingEnabled(Boolean textifyFormattingEnabled) {
-			this.textifyFormattingEnabled = textifyFormattingEnabled;
-			return this;
-		}
-
-		public RecognitionConfig.Builder textifyFormattingRules(String textifyFormattingRules) {
-			this.textifyFormattingRules = textifyFormattingRules;
-			return this;
-		}
-		public RecognitionConfig.Builder wordDetails(int wordDetails) {
-			this.wordDetails = wordDetails;
-			return this;
-		}
-
-		public RecognitionConfig.Builder wordHints(String wordHints) {
-			this.wordHints = wordHints;
-			return this;
-		}
-
-		public RecognitionConfig.Builder loggingTag(String value) {
-			this.loggingTag = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder inferAgeEnabled(Boolean value) {
-			this.inferAgeEnabled = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder inferEmotionEnabled(Boolean value) {
-			this.inferEmotionEnabled = value;
-			return this;
-		}
-
-		public RecognitionConfig.Builder inferGenderEnabled(Boolean value) {
-			this.inferGenderEnabled = value;
-			return this;
-		}
-	}
+    private HashMap<String, String> map = new HashMap<>();
+
+    public Boolean getNoInputTimeoutEnabled() {
+        return getBoolean("noInputTimeout.enabled");
+    }
+
+    private void setNoInputTimeoutEnabled(Boolean noInputTimeoutEnabled) {
+        put("noInputTimeout.enabled", noInputTimeoutEnabled);
+    }
+
+    public Integer getNoInputTimeout() {
+        return getInteger("noInputTimeout.value");
+    }
+
+    private void setNoInputTimeout(Integer noInputTimeout) {
+        put("noInputTimeout.value", noInputTimeout);
+    }
+
+    public Boolean getRecognitionTimeoutEnabled() {
+        return getBoolean("recognitionTimeout.enabled");
+    }
+
+    private void setRecognitionTimeoutEnabled(Boolean recognitionTimeoutEnabled) {
+        put("recognitionTimeout.enabled", recognitionTimeoutEnabled);
+    }
+
+    public Integer getRecognitionTimeout() {
+        return getInteger("recognitionTimeout.value");
+    }
+
+    private void setRecognitionTimeout(Integer recognitionTimeout) {
+        put("recognitionTimeout.value", recognitionTimeout);
+    }
+
+    public Boolean getStartInputTimers() {
+        return getBoolean("decoder.startInputTimers");
+    }
+
+    private void setStartInputTimers(Boolean decoderStartInputTimers) {
+        put("decoder.startInputTimers", decoderStartInputTimers);
+    }
+
+    public Integer getMaxSentences() {
+        return getInteger("decoder.maxSentences");
+    }
+
+    private void setMaxSentences(Integer decoderMaxSentences) {
+        put("decoder.maxSentences", decoderMaxSentences);
+    }
+
+    public Integer getHeadMarginMiliseconds() {
+        return getInteger("endpointer.headMargin");
+    }
+
+    private void setHeadMarginMiliseconds(Integer endpointerHeadMargin) {
+        put("endpointer.headMargin", endpointerHeadMargin);
+    }
+
+    public Integer getTailMarginMiliseconds() {
+        return getInteger("endpointer.tailMargin");
+    }
+
+    private void setTailMarginMiliseconds(Integer endpointerTailMargin) {
+        put("endpointer.tailMargin", endpointerTailMargin);
+    }
+
+    public Integer getWaitEndMiliseconds() {
+        return getInteger("endpointer.waitEnd");
+    }
+
+    private void setWaitEndMiliseconds(Integer endpointerWaitEnd) {
+        put("endpointer.waitEnd", endpointerWaitEnd);
+    }
+
+    public Integer getEndpointerLevelThreshold() {
+        return getInteger("endpointer.levelThreshold");
+    }
+
+    private void setEndpointerLevelThreshold(Integer endpointerLevelThreshold) {
+        put("endpointer.levelThreshold", endpointerLevelThreshold);
+    }
+
+    public Integer getEndpointerLevelMode() {
+        return getInteger("endpointer.levelMode");
+    }
+
+    private void setEndpointerLevelMode(Integer endpointerLevelMode) {
+        put("endpointer.levelMode", endpointerLevelMode);
+    }
+
+    public Integer getEndpointerAutoLevelLen() {
+        return getInteger("endpointer.autoLevelLen");
+    }
+
+    private void setEndpointerAutoLevelLen(Integer endpointerAutoLevelLen) {
+        put("endpointer.autoLevelLen", endpointerAutoLevelLen);
+    }
+
+    public Boolean getContinuousMode() {
+        return getBoolean("decoder.continuousMode");
+    }
+
+    private void setContinuousMode(Boolean continuousMode) {
+        put("decoder.continuousMode", continuousMode);
+    }
+
+    public Integer getConfidenceThreshold() {
+        return getInteger("decoder.confidenceThreshold");
+    }
+
+    private void setConfidenceThreshold(Integer decoderConfidenceThreshold) {
+        put("decoder.confidenceThreshold", decoderConfidenceThreshold);
+    }
+
+    public Integer getWordDetails() {
+        return getInteger("decoder.wordDetails");
+    }
+
+    public void setWordDetails(Integer wordDetails) {
+        put("decoder.wordDetails", wordDetails);
+    }
+
+    public String getWordHints() {
+        return getString("hints.words");
+    }
+
+    public void setWordHints(String wordHints) {
+        put("hints.words", wordHints);
+    }
+
+    public String getTextifyFormattingRules() {
+        return getString("textify.formatting.rules");
+    }
+
+    public void setTextifyFormattingRules(String textifyFormattingRules) {
+        put("textify.formatting.rules", textifyFormattingRules);
+    }
+
+    public Boolean getTextifyFormattingEnabled() {
+        return getBoolean("textify.formatting.enabled");
+    }
+
+    public void setTextifyFormattingEnabled(Boolean textifyFormattingEnabled) {
+        put("textify.formatting.enabled", textifyFormattingEnabled);
+    }
+
+    public Boolean getTextifyEnabled() {
+        return getBoolean("textify.enabled");
+    }
+
+    public void setTextifyEnabled(Boolean textifyEnabled) {
+        put("textify.enabled", textifyEnabled);
+    }
+
+    public String getLoggingTag() {
+        return getString("loggingTag");
+    }
+
+    private void setLoggingTag(String loggingTag) {
+        put("loggingTag", loggingTag);
+    }
+
+    public String getAccountTag() {
+        return getString("license.manager.accountTag");
+    }
+
+    private void setAccountTag(String accountTag) {
+        put("license.manager.accountTag", accountTag);
+    }
+
+    public void setVerifyBuffer(Boolean verifyBuffer) {
+        put("Verify-Buffer-Utterance", verifyBuffer);
+    }
+
+    public Boolean getVerifyBuffer() {
+        return getBoolean("Verify-Buffer-Utterance");
+    }
+
+    public Boolean getInferAgeEnabled() {
+        return getBoolean("Infer-age-enabled");
+    }
+
+    public void setInferAgeEnabled(Boolean inferAgeEnabled) {
+        put("Infer-age-enabled", inferAgeEnabled);
+    }
+
+    public Boolean getInferEmotionEnabled() {
+        return getBoolean("Infer-emotion-enabled");
+    }
+
+    public void setInferEmotionEnabled(Boolean inferEmotionEnabled) {
+        put("Infer-emotion-enabled", inferEmotionEnabled);
+    }
+
+    public Boolean getInferGenderEnabled() {
+        return getBoolean("Infer-gender-enabled");
+    }
+
+    public void setInferGenderEnabled(Boolean inferGenderEnabled) {
+        put("Infer-gender-enabled", inferGenderEnabled);
+    }
+
+    private void put(String key, Object value) {
+        if (value != null)
+            this.map.put(key, value.toString());
+    }
+
+    private Boolean getBoolean(String key) {
+        String value = this.map.get(key);
+        return (value == null ? null : Boolean.parseBoolean(value));
+    }
+
+    private Integer getInteger(String key) {
+        String value = this.map.get(key);
+        return (value == null ? null : Integer.parseInt(value));
+    }
+
+    private String getString(String key) {
+        return this.map.get(key);
+    }
+
+    public HashMap<String, String> getParameterMap() {
+        return this.map;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder str = new StringBuilder("RecognitionConfig [");
+        for (Iterator<String> it = map.keySet().iterator(); it.hasNext();) {
+            String key = it.next();
+            if (map.get(key) != null && map.get(key).trim().length() > 0) {
+                str.append(key + "=" + map.get(key));
+            }
+
+            if (it.hasNext()) {
+                str.append(", ");
+            }
+        }
+
+        str.append("]");
+        return str.toString();
+    }
+
+    /**
+     * Creates a new instance of the object builder.
+     * 
+     * @return the Builder object.
+     */
+    public static RecognitionConfig.Builder builder() {
+        return new RecognitionConfig.Builder();
+    }
+
+    /**
+     * The Builder object.
+     *
+     */
+    public static class Builder {
+
+        private Boolean continuousMode;
+        private Integer confidenceThreshold;
+        private Integer maxSentences;
+        private Integer noInputTimeoutMilis;
+        private Integer recognitionTimeoutSeconds;
+        private Integer headMarginMilis;
+        private Integer tailMarginMilis;
+        private Integer waitEndMilis;
+        private Boolean recognitionTimeoutEnabled;
+        private Boolean noInputTimeoutEnabled;
+        private Boolean startInputTimers;
+        private Integer endPointerAutoLevelLen;
+        private Integer endPointerLevelMode;
+        private Integer endPointerLevelThreshold;
+        private Integer wordDetails;
+        private String wordHints;
+        private Boolean textifyEnabled;
+        private Boolean textifyFormattingEnabled;
+        private String textifyFormattingRules;
+        private String loggingTag;
+        private String accountTag;
+        private Boolean verifyBuffer;
+
+        // speech server
+        private Boolean inferAgeEnabled;
+        private Boolean inferEmotionEnabled;
+        private Boolean inferGenderEnabled;
+
+        /**
+         * Creates a new instance of the RecognitionConfig object.
+         * 
+         * @return a RecognitionConfig instance.
+         */
+        public RecognitionConfig build() {
+            RecognitionConfig config = new RecognitionConfig();
+            config.setContinuousMode(continuousMode);
+            config.setConfidenceThreshold(confidenceThreshold);
+            config.setMaxSentences(maxSentences);
+            config.setNoInputTimeout(noInputTimeoutMilis);
+            config.setRecognitionTimeout(recognitionTimeoutSeconds);
+            config.setHeadMarginMiliseconds(headMarginMilis);
+            config.setTailMarginMiliseconds(tailMarginMilis);
+            config.setWaitEndMiliseconds(waitEndMilis);
+            config.setStartInputTimers(startInputTimers);
+            config.setEndpointerAutoLevelLen(endPointerAutoLevelLen);
+            config.setEndpointerLevelMode(endPointerLevelMode);
+            config.setEndpointerLevelThreshold(endPointerLevelThreshold);
+            config.setNoInputTimeoutEnabled(noInputTimeoutEnabled);
+            config.setRecognitionTimeoutEnabled(recognitionTimeoutEnabled);
+            config.setWordDetails(wordDetails);
+            config.setWordHints(wordHints);
+            config.setTextifyEnabled(textifyEnabled);
+            config.setTextifyFormattingEnabled(textifyFormattingEnabled);
+            config.setTextifyFormattingRules(textifyFormattingRules);
+            config.setLoggingTag(loggingTag);
+            config.setAccountTag(accountTag);
+            config.setVerifyBuffer(verifyBuffer);
+
+            config.setInferAgeEnabled(inferAgeEnabled);
+            config.setInferEmotionEnabled(inferEmotionEnabled);
+            config.setInferGenderEnabled(inferGenderEnabled);
+
+            return config;
+        }
+
+        public RecognitionConfig.Builder continuousMode(Boolean value) {
+            this.continuousMode = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder confidenceThreshold(Integer value) {
+            this.confidenceThreshold = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder maxSentences(Integer value) {
+            this.maxSentences = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder noInputTimeoutMilis(Integer value) {
+            this.noInputTimeoutMilis = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder recognitionTimeoutSeconds(Integer value) {
+            this.recognitionTimeoutSeconds = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder headMarginMilis(Integer value) {
+            this.headMarginMilis = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder tailMarginMilis(Integer value) {
+            this.tailMarginMilis = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder waitEndMilis(Integer value) {
+            this.waitEndMilis = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder startInputTimers(Boolean value) {
+            this.startInputTimers = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder endPointerAutoLevelLen(Integer value) {
+            this.endPointerAutoLevelLen = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder endPointerLevelMode(Integer value) {
+            this.endPointerLevelMode = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder endPointerLevelThreshold(Integer value) {
+            this.endPointerLevelThreshold = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder noInputTimeoutEnabled(Boolean value) {
+            this.noInputTimeoutEnabled = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder recognitionTimeoutEnabled(Boolean value) {
+            this.recognitionTimeoutEnabled = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder textifyEnabled(Boolean textifyEnabled) {
+            this.textifyEnabled = textifyEnabled;
+            return this;
+        }
+
+        public RecognitionConfig.Builder textifyFormattingEnabled(Boolean textifyFormattingEnabled) {
+            this.textifyFormattingEnabled = textifyFormattingEnabled;
+            return this;
+        }
+
+        public RecognitionConfig.Builder textifyFormattingRules(String textifyFormattingRules) {
+            this.textifyFormattingRules = textifyFormattingRules;
+            return this;
+        }
+
+        public RecognitionConfig.Builder wordDetails(int wordDetails) {
+            this.wordDetails = wordDetails;
+            return this;
+        }
+
+        public RecognitionConfig.Builder wordHints(String wordHints) {
+            this.wordHints = wordHints;
+            return this;
+        }
+
+        public RecognitionConfig.Builder loggingTag(String value) {
+            this.loggingTag = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder accountTag(String value) {
+            this.accountTag = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder verifyBuffer(boolean value) {
+            this.verifyBuffer = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder inferAgeEnabled(Boolean value) {
+            this.inferAgeEnabled = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder inferEmotionEnabled(Boolean value) {
+            this.inferEmotionEnabled = value;
+            return this;
+        }
+
+        public RecognitionConfig.Builder inferGenderEnabled(Boolean value) {
+            this.inferGenderEnabled = value;
+            return this;
+        }
+    }
 
 }

--- a/recognizer/src/test/java/br/com/cpqd/asr/recognizer/SpeechServerTest.java
+++ b/recognizer/src/test/java/br/com/cpqd/asr/recognizer/SpeechServerTest.java
@@ -1,0 +1,60 @@
+package br.com.cpqd.asr.recognizer;
+
+import br.com.cpqd.asr.protocol.WordDetail;
+import br.com.cpqd.asr.recognizer.model.RecognitionConfig;
+import br.com.cpqd.asr.recognizer.model.RecognitionResult;
+import br.com.cpqd.asr.recognizer.model.RecognitionResultCode;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class SpeechServerTest {
+
+    private static final String url = "ws://localhost:8025/asr-server/asr";
+//    private static final String url = "wss://speech.cpqd.com.br/asr/ws/v2/recognize/8k";
+    private static final String user = "dsda";
+    private static final String passwd = "futuro";
+    private static final String filename = "./src/test/resources/audio/pizza-veg-8k.wav";
+    private static final String lmName = "builtin:slm/general";
+
+    @Test
+    public void basicGrammar() {
+        String filename = "./src/test/resources/audio/cpf_8k.wav";
+        String lmName = "builtin:grammar/cpf";
+
+        SpeechRecognizer recognizer = null;
+        try {
+            recognizer = SpeechRecognizer.builder().serverURL(url).credentials(user, passwd).
+                    version("2.3").channelIdentifier("1234@asr").
+                    recogConfig(RecognitionConfig.builder().
+                            maxSentences(1).wordDetails(WordDetail.FIRST.getValue()).
+                            inferAgeEnabled(true).inferEmotionEnabled(true).inferGenderEnabled(true).
+                            build()).
+                    build();
+            AudioSource audio = new FileAudioSource(new File(filename));
+            recognizer.recognize(audio, LanguageModelList.builder().addFromURI(lmName).build());
+            List<RecognitionResult> results = recognizer.waitRecognitionResult();
+
+            assertTrue("Number of alternatives is " + results.get(0).getAlternatives().size(),
+                    results.get(0).getAlternatives().size() > 0);
+            assertTrue("Score is higher than 90", results.get(0).getAlternatives().get(0).getConfidence() > 90);
+            assertTrue("Result is recognized", results.get(0).getResultCode() == RecognitionResultCode.RECOGNIZED);
+            assertTrue("Contains interpretation",
+                    results.get(0).getAlternatives().get(0).getInterpretations().size() > 0);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Test failed: " + e.getMessage());
+        } finally {
+            try {
+                if (recognizer != null)
+                    recognizer.close();
+            } catch (IOException e) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added new atributes on CREATE SESSION, START RECOG, SET PARAMS and RECOG RESULT messages. These atribs are handled by the Speech Server and ignored by the ASR Server.
The client SDK allows to define the protocol version but it has no validation if you are using the correct set of attributes.
The server will reply the client messages with the same protocol version. It has no validation rules implemented at this time. This behavior allows the SDK to be used with the Speech Server and the ASR Server.